### PR TITLE
Updated vvp example to match normative requirement

### DIFF
--- a/draft-hardman-verifiable-voice-protocol.md
+++ b/draft-hardman-verifiable-voice-protocol.md
@@ -243,7 +243,7 @@ An example will help. In its JSON-serialized form, a typical VVP passport for an
 {
   "header": {
     "alg": "EdDSA",
-    "typ": "JWT",
+    "typ": "passport",
     "ppt": "vvp",
     "kid": "https://agentsrus.net/oobi/EMC.../agent/EAx..."
   },


### PR DESCRIPTION
The normative requirement below this example says that `typ` should be passport so I changed the example to match.